### PR TITLE
Surface Hangar/CurseForge API error bodies on failed uploads

### DIFF
--- a/.github/workflows/publish-platforms.yml
+++ b/.github/workflows/publish-platforms.yml
@@ -196,11 +196,16 @@ jobs:
               files:[{platforms:["PAPER"]}]}')
 
           # 3. Upload (versionUpload part + the jar as the files part).
-          curl -fsS -X POST \
+          HTTP=$(curl -sS -o hangar_resp.json -w '%{http_code}' -X POST \
             "https://hangar.papermc.io/api/v1/projects/${OWNER}/${SLUG}/upload" \
             -H "Authorization: ${JWT}" \
             -F "versionUpload=${UPLOAD};type=application/json" \
-            -F "files=@${JAR}"
+            -F "files=@${JAR}")
+          echo "Hangar HTTP $HTTP; response: $(cat hangar_resp.json 2>/dev/null)"
+          if [ "$HTTP" -lt 200 ] || [ "$HTTP" -ge 300 ]; then
+            echo "::error::Hangar upload failed (HTTP $HTTP): $(cat hangar_resp.json 2>/dev/null)"
+            exit 1
+          fi
           echo "Hangar: published ${SLUG} ${VERSION}"
 
       # ------------------------------------------------------------ CurseForge
@@ -235,9 +240,16 @@ jobs:
             --arg cl "$CHANGELOG" \
             --argjson gv "$GV" \
             '{changelog:$cl, changelogType:"markdown", releaseType:"release", gameVersions:$gv}')
-          curl -fsS -X POST \
+          echo "CurseForge gameVersion ids: $(echo "$GV" | jq -c '.')"
+          # Capture status + body so an API rejection (e.g. 400) shows why, instead of a bare curl exit 22.
+          HTTP=$(curl -sS -o cf_resp.json -w '%{http_code}' -X POST \
             "https://minecraft.curseforge.com/api/projects/${CF_ID}/upload-file" \
             -H "X-Api-Token: ${CURSEFORGE_TOKEN}" \
             -F "metadata=${META};type=application/json" \
-            -F "file=@${JAR}"
+            -F "file=@${JAR}")
+          echo "CurseForge HTTP $HTTP; response: $(cat cf_resp.json 2>/dev/null)"
+          if [ "$HTTP" -lt 200 ] || [ "$HTTP" -ge 300 ]; then
+            echo "::error::CurseForge upload failed (HTTP $HTTP): $(cat cf_resp.json 2>/dev/null)"
+            exit 1
+          fi
           echo "CurseForge: uploaded to project ${CF_ID}"


### PR DESCRIPTION
## Why

When publishing BentoBox 3.18.0, the CurseForge upload failed with a bare:

```
curl: (22) The requested URL returned error: 400
```

The upload steps use `curl -fsS`, which discards the response body — so there's no way to tell *why* CurseForge rejected the request.

## What

- CurseForge and Hangar upload steps now capture the HTTP status and response body (`-o file -w '%{http_code}'`), print them, and fail with an `::error::` that includes the body on any non-2xx.
- Also logs the resolved CurseForge `gameVersion` ids before upload.
- No behaviour change on success.

This is purely diagnostics so we can see the actual 400 reason on the next publish run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)