### PR TITLE
CurseForge: resolve versions under the plugin gameVersionTypeID (fixes 'invalid dependency')

### DIFF
--- a/.github/workflows/publish-platforms.yml
+++ b/.github/workflows/publish-platforms.yml
@@ -25,6 +25,10 @@ on:
         description: "CurseForge numeric project id. Blank = skip CurseForge."
         type: string
         default: ""
+      curseforge_version_type_id:
+        description: "CurseForge gameVersionTypeID to resolve MC version names under. 1 = the flat Minecraft type used by Bukkit/Paper plugin projects (the per-version mod types are rejected as 'invalid dependency')."
+        type: string
+        default: "1"
       game_versions:
         description: "Comma-separated Minecraft versions, e.g. 1.21.5,1.21.6,1.21.7"
         type: string
@@ -216,20 +220,26 @@ jobs:
           CF_ID: ${{ inputs.curseforge_id }}
           JAR: ${{ steps.meta.outputs.jar }}
           GAME_VERSIONS: ${{ inputs.game_versions }}
+          CF_VERSION_TYPE_ID: ${{ inputs.curseforge_version_type_id }}
           CHANGELOG: ${{ steps.meta.outputs.changelog }}
         run: |
           set -euo pipefail
 
           # 1. Map MC version names -> CurseForge numeric gameVersion ids.
+          #    Each MC version exists under several gameVersionTypeIDs (per-version mod
+          #    types, "addons", etc.); a plugin project only accepts ids under the flat
+          #    Minecraft type (id 1) - the others fail with "invalid dependency". So
+          #    resolve names within CF_VERSION_TYPE_ID, not just the first name match.
           curl -fsS -H "X-Api-Token: ${CURSEFORGE_TOKEN}" \
             "https://minecraft.curseforge.com/api/game/versions" > cf_versions.json
           IDS=()
           for v in ${GAME_VERSIONS//,/ }; do
-            id=$(jq -r --arg n "$v" '.[] | select(.name==$n) | .id' cf_versions.json | head -n1)
+            id=$(jq -r --arg n "$v" --argjson t "$CF_VERSION_TYPE_ID" \
+              '.[] | select(.name==$n and .gameVersionTypeID==$t) | .id' cf_versions.json | head -n1)
             if [ -n "$id" ] && [ "$id" != "null" ]; then
               IDS+=("$id")
             else
-              echo "::warning::CurseForge has no game version id for '$v' (skipped)"
+              echo "::warning::CurseForge has no game version id for '$v' under type ${CF_VERSION_TYPE_ID} (skipped)"
             fi
           done
           if [ ${#IDS[@]} -eq 0 ]; then echo "::error::No CurseForge game versions resolved"; exit 1; fi


### PR DESCRIPTION
## Root cause (confirmed via the CurseForge API)

Every CurseForge upload for BentoBox 3.18.0 was rejected with `1009: "Invalid game version ID: N belongs to an invalid dependency"` — for **every** version, not just 26.2.

Each MC version name exists under several `gameVersionTypeID`s. For `1.21.11`:

| id | gameVersionTypeID | type |
|----|----|----|
| 14406 | 77784 | `minecraft-1-21` (mod type) |
| **14417** | **1** | flat **Minecraft** type |
| 16127 | 615 | `addons` |

The old `head -n1` name match picked the **mod** type id (77784/86297/…), which a **Bukkit/Paper plugin** project rejects. Plugin projects only accept ids under the flat Minecraft type, **`gameVersionTypeID = 1`**.

## Fix

Resolve each version name to the id whose `gameVersionTypeID` equals a new `curseforge_version_type_id` input (**default `1`**). Versions not present under that type are warned + skipped.

This also fixes **26.2**: it exists under type 1 (id `16500`) even though its mod-type id (`16498`) is rejected — so the full `1.21.5–26.2` list now publishes.

Stacks on top of the 1009 drop-and-retry safety net (#8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)