### PR TITLE
fix(publish): read release body via env, not inline shell interpolation

### DIFF
--- a/.github/workflows/publish-platforms.yml
+++ b/.github/workflows/publish-platforms.yml
@@ -126,6 +126,13 @@ jobs:
 
       - name: Resolve version, jar and changelog
         id: meta
+        env:
+          # Pass the release body through the environment, never inline it into
+          # the script. Inline `${{ toJSON(github.event.release.body) }}` still
+          # leaves backticks and $(...) live inside the double-quoted shell
+          # string, so a body containing e.g. `code` breaks the run (command
+          # not found) and is a shell-injection vector. Read via "$RELEASE_BODY".
+          RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           set -euo pipefail
           # Version: explicit input (manual runs) wins, else the release tag.
@@ -152,7 +159,7 @@ jobs:
           # Stage the jar + changelog for the platform jobs.
           mkdir -p out
           cp "$JAR" out/
-          BODY=${{ toJSON(github.event.release.body) }}
+          BODY="${RELEASE_BODY:-}"
           if [ -z "$BODY" ] || [ "$BODY" = "null" ]; then BODY="Release $VERSION"; fi
           printf '%s' "$BODY" > out/changelog.md
 


### PR DESCRIPTION
## Problem

`publish-platforms.yml`'s `prep` step staged the changelog with:

```yaml
BODY=${{ toJSON(github.event.release.body) }}
```

`toJSON` escapes `"`, `\` and newlines, but **not backticks or `$(...)`**, which remain live inside the resulting double-quoted shell string. A release whose body contains an inline `` `code` `` span therefore executes it as a command:

```
line 26: Util.componentToLegacy: command not found
##[error]Process completed with exit code 127.
```

This broke BentoBox's 3.18.1 CurseForge/Hangar publish ([failed run](https://github.com/BentoBoxWorld/BentoBox/actions/runs/28496479906/job/84463735981)), is a **shell-injection vector** (a crafted release body could run arbitrary commands on the runner), and also left literal `\r\n` in `changelog.md`.

## Fix

Pass the body through the environment and read it with `"$RELEASE_BODY"`, so the shell never parses its contents:

```yaml
    env:
      RELEASE_BODY: ${{ github.event.release.body }}
    run: |
      ...
      BODY="${RELEASE_BODY:-}"
      if [ -z "$BODY" ] || [ "$BODY" = "null" ]; then BODY="Release $VERSION"; fi
```

Backticks, `$(...)` and `$VAR` in release notes are now preserved literally, real newlines survive, and manual `workflow_dispatch` (no release event → empty body) still falls back to `Release $VERSION`.

## Blast radius

This reusable workflow is used by every BentoBox repo's publish, so the fix applies org-wide. Consumers pin it by SHA; they'll pick up the fix when they re-pin to the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153KLwL66bB31pTc4BtsTMd